### PR TITLE
multi-target-group: support passing in cidr blocks as flag

### DIFF
--- a/pkg/backend/endpoint_resolver.go
+++ b/pkg/backend/endpoint_resolver.go
@@ -3,6 +3,7 @@ package backend
 import (
 	"context"
 	"fmt"
+	"net/netip"
 
 	awssdk "github.com/aws/aws-sdk-go/aws"
 	"github.com/go-logr/logr"
@@ -13,6 +14,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/k8s"
+	"sigs.k8s.io/aws-load-balancer-controller/pkg/networking"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -36,9 +38,10 @@ type EndpointResolver interface {
 }
 
 // NewDefaultEndpointResolver constructs new defaultEndpointResolver
-func NewDefaultEndpointResolver(k8sClient client.Client, podInfoRepo k8s.PodInfoRepo, failOpenEnabled bool, endpointSliceEnabled bool, logger logr.Logger) *defaultEndpointResolver {
+func NewDefaultEndpointResolver(k8sClient client.Client, cidrs []netip.Prefix, podInfoRepo k8s.PodInfoRepo, failOpenEnabled bool, endpointSliceEnabled bool, logger logr.Logger) *defaultEndpointResolver {
 	return &defaultEndpointResolver{
 		k8sClient:            k8sClient,
+		cidrs:                cidrs,
 		podInfoRepo:          podInfoRepo,
 		failOpenEnabled:      failOpenEnabled,
 		endpointSliceEnabled: endpointSliceEnabled,
@@ -50,7 +53,9 @@ var _ EndpointResolver = &defaultEndpointResolver{}
 
 // default implementation for EndpointResolver
 type defaultEndpointResolver struct {
-	k8sClient   client.Client
+	k8sClient client.Client
+	// cidrs specifies the set of IP ranges to watch for in CIDR notation.
+	cidrs       []netip.Prefix
 	podInfoRepo k8s.PodInfoRepo
 	// [NodePort Endpoint] if fail-open enabled, then nodes that have `Unknown` ready condition will be included if there is no other node with `True` ready condition.
 	// [Pod Endpoint] if fail-open enabled, then containerRead pods on nodes that have `Unknown` ready condition will be included if there is no other pods that are ready.
@@ -169,6 +174,17 @@ func (r *defaultEndpointResolver) resolvePodEndpointsWithEndpointsData(ctx conte
 					r.logger.Info("ignore pod Endpoint with non-existent podInfo", "podKey", podKey.String())
 					continue
 				}
+
+				if len(r.cidrs) > 0 {
+					ip, err := netip.ParseAddr(epAddr)
+					if err != nil {
+						return nil, false, fmt.Errorf("parse ip addr: %w", err)
+					}
+					if !networking.IsIPWithinCIDRs(ip, r.cidrs) {
+						continue
+					}
+				}
+
 				podEndpoint := buildPodEndpoint(pod, epAddr, epPort)
 				if ep.Conditions.Ready != nil && *ep.Conditions.Ready {
 					readyPodEndpoints = append(readyPodEndpoints, podEndpoint)

--- a/pkg/targetgroupbinding/resource_manager.go
+++ b/pkg/targetgroupbinding/resource_manager.go
@@ -41,10 +41,10 @@ type ResourceManager interface {
 func NewDefaultResourceManager(k8sClient client.Client, elbv2Client services.ELBV2, ec2Client services.EC2,
 	podInfoRepo k8s.PodInfoRepo, sgManager networking.SecurityGroupManager, sgReconciler networking.SecurityGroupReconciler,
 	vpcInfoProvider networking.VPCInfoProvider,
-	vpcID string, clusterName string, failOpenEnabled bool, endpointSliceEnabled bool, disabledRestrictedSGRulesFlag bool,
+	vpcID string, clusterName string, cidrs []netip.Prefix, failOpenEnabled bool, endpointSliceEnabled bool, disabledRestrictedSGRulesFlag bool,
 	eventRecorder record.EventRecorder, logger logr.Logger) *defaultResourceManager {
-	targetsManager := NewCachedTargetsManager(elbv2Client, logger)
-	endpointResolver := backend.NewDefaultEndpointResolver(k8sClient, podInfoRepo, failOpenEnabled, endpointSliceEnabled, logger)
+	targetsManager := NewCachedTargetsManager(elbv2Client, cidrs, logger)
+	endpointResolver := backend.NewDefaultEndpointResolver(k8sClient, cidrs, podInfoRepo, failOpenEnabled, endpointSliceEnabled, logger)
 
 	nodeInfoProvider := networking.NewDefaultNodeInfoProvider(ec2Client, logger)
 	podENIResolver := networking.NewDefaultPodENIInfoResolver(k8sClient, ec2Client, nodeInfoProvider, vpcID, logger)

--- a/pkg/targetgroupbinding/targets_manager.go
+++ b/pkg/targetgroupbinding/targets_manager.go
@@ -2,13 +2,17 @@ package targetgroupbinding
 
 import (
 	"context"
+	"fmt"
+	"net/netip"
+	"sync"
+	"time"
+
 	"github.com/aws/aws-sdk-go/aws"
 	elbv2sdk "github.com/aws/aws-sdk-go/service/elbv2"
 	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/util/cache"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/aws/services"
-	"sync"
-	"time"
+	"sigs.k8s.io/aws-load-balancer-controller/pkg/networking"
 )
 
 const (
@@ -30,7 +34,7 @@ type TargetsManager interface {
 }
 
 // NewCachedTargetsManager constructs new cachedTargetsManager
-func NewCachedTargetsManager(elbv2Client services.ELBV2, logger logr.Logger) *cachedTargetsManager {
+func NewCachedTargetsManager(elbv2Client services.ELBV2, cidrs []netip.Prefix, logger logr.Logger) *cachedTargetsManager {
 	return &cachedTargetsManager{
 		elbv2Client:                elbv2Client,
 		targetsCache:               cache.NewExpiring(),
@@ -38,6 +42,7 @@ func NewCachedTargetsManager(elbv2Client services.ELBV2, logger logr.Logger) *ca
 		registerTargetsChunkSize:   defaultRegisterTargetsChunkSize,
 		deregisterTargetsChunkSize: defaultDeregisterTargetsChunkSize,
 		logger:                     logger,
+		cidrs:                      cidrs,
 	}
 }
 
@@ -63,6 +68,9 @@ type cachedTargetsManager struct {
 	registerTargetsChunkSize int
 	// chunk size for deregisterTargets API call.
 	deregisterTargetsChunkSize int
+
+	// cidrs specifies the set of IP ranges to watch for in CIDR notation.
+	cidrs []netip.Prefix
 
 	logger logr.Logger
 }
@@ -199,6 +207,15 @@ func (m *cachedTargetsManager) listTargetsFromAWS(ctx context.Context, tgARN str
 
 	listedTargets := make([]TargetInfo, 0, len(resp.TargetHealthDescriptions))
 	for _, elem := range resp.TargetHealthDescriptions {
+		if len(m.cidrs) > 0 {
+			ip, err := netip.ParseAddr(aws.StringValue(elem.Target.Id))
+			if err != nil {
+				return nil, fmt.Errorf("parse ip addr: %w", err)
+			}
+			if !networking.IsIPWithinCIDRs(ip, m.cidrs) {
+				continue
+			}
+		}
 		listedTargets = append(listedTargets, TargetInfo{
 			Target:       *elem.Target,
 			TargetHealth: elem.TargetHealth,


### PR DESCRIPTION
This effectively passes down the CIDR blocks as a flag and filters out the list of targets that are returned from aws.
