### PR TITLE
v2.8.1 multi-target-group: support passing in cidr blocks as flag

### DIFF
--- a/main.go
+++ b/main.go
@@ -108,7 +108,7 @@ func main() {
 	subnetResolver := networking.NewDefaultSubnetsResolver(azInfoProvider, cloud.EC2(), cloud.VpcID(), controllerCFG.ClusterName, ctrl.Log.WithName("subnets-resolver"))
 	tgbResManager := targetgroupbinding.NewDefaultResourceManager(mgr.GetClient(), cloud.ELBV2(), cloud.EC2(),
 		podInfoRepo, sgManager, sgReconciler, vpcInfoProvider,
-		cloud.VpcID(), controllerCFG.ClusterName, controllerCFG.FeatureGates.Enabled(config.EndpointsFailOpen), controllerCFG.EnableEndpointSlices, controllerCFG.DisableRestrictedSGRules,
+		cloud.VpcID(), controllerCFG.ClusterName, controllerCFG.CIDRBlocks, controllerCFG.FeatureGates.Enabled(config.EndpointsFailOpen), controllerCFG.EnableEndpointSlices, controllerCFG.DisableRestrictedSGRules,
 		controllerCFG.ServiceTargetENISGTags, mgr.GetEventRecorderFor("targetGroupBinding"), ctrl.Log)
 	backendSGProvider := networking.NewBackendSGProvider(controllerCFG.ClusterName, controllerCFG.BackendSecurityGroup,
 		cloud.VpcID(), cloud.EC2(), mgr.GetClient(), controllerCFG.DefaultTags, ctrl.Log.WithName("backend-sg-provider"))

--- a/pkg/config/controller_config.go
+++ b/pkg/config/controller_config.go
@@ -1,6 +1,8 @@
 package config
 
 import (
+	"fmt"
+	"net"
 	"strings"
 	"time"
 
@@ -15,6 +17,7 @@ import (
 const (
 	flagLogLevel                                     = "log-level"
 	flagK8sClusterName                               = "cluster-name"
+	flagCIDRBlocks                                   = "cidr-blocks"
 	flagDefaultTags                                  = "default-tags"
 	flagDefaultTargetType                            = "default-target-type"
 	flagExternalManagedTags                          = "external-managed-tags"
@@ -102,6 +105,9 @@ type ControllerConfig struct {
 	// DisableRestrictedSGRules specifies whether to use restricted security group rules
 	DisableRestrictedSGRules bool
 
+	// CIDRBlocks specifies the set of IP ranges to watch for in CIDR notation.
+	CIDRBlocks []string
+
 	FeatureGates FeatureGates
 }
 
@@ -110,6 +116,7 @@ func (cfg *ControllerConfig) BindFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&cfg.LogLevel, flagLogLevel, defaultLogLevel,
 		"Set the controller log level - info(default), debug")
 	fs.StringVar(&cfg.ClusterName, flagK8sClusterName, "", "Kubernetes cluster name")
+	fs.StringSliceVar(&cfg.CIDRBlocks, flagCIDRBlocks, []string{}, "CIDR ranges to watch over")
 	fs.StringToStringVar(&cfg.DefaultTags, flagDefaultTags, nil,
 		"Default AWS Tags that will be applied to all AWS resources managed by this controller")
 	fs.StringVar(&cfg.DefaultTargetType, flagDefaultTargetType, string(elbv2.TargetTypeInstance),
@@ -148,6 +155,14 @@ func (cfg *ControllerConfig) BindFlags(fs *pflag.FlagSet) {
 func (cfg *ControllerConfig) Validate() error {
 	if len(cfg.ClusterName) == 0 {
 		return errors.New("kubernetes cluster name must be specified")
+	}
+
+	if len(cfg.CIDRBlocks) > 0 {
+		for _, cidr := range cfg.CIDRBlocks {
+			if _, _, err := net.ParseCIDR(cidr); err != nil {
+				return fmt.Errorf("parse cidr: %w", err)
+			}
+		}
 	}
 
 	if err := cfg.validateDefaultTagsCollisionWithTrackingTags(); err != nil {

--- a/pkg/targetgroupbinding/networking_manager.go
+++ b/pkg/targetgroupbinding/networking_manager.go
@@ -201,7 +201,7 @@ func (m *defaultNetworkingManager) reconcileWithIngressPermissionsPerSG(ctx cont
 	computedForAllTGBs := m.consolidateIngressPermissionsPerSGByTGB(ctx, tgbsWithNetworking)
 	aggregatedIngressPermissionsPerSG := m.computeAggregatedIngressPermissionsPerSG(ctx)
 
-	permissionSelector := labels.SelectorFromSet(labels.Set{tgbNetworkingIPPermissionLabelKey: tgbNetworkingIPPermissionLabelValue})
+	permissionSelector := labels.SelectorFromSet(labels.Set{tgbNetworkingIPPermissionLabelKey: m.clusterName})
 	var sgReconciliationErrors []error
 	for sgID, permissions := range aggregatedIngressPermissionsPerSG {
 		if err := m.sgReconciler.ReconcileIngress(ctx, sgID, permissions,
@@ -420,7 +420,7 @@ func (m *defaultNetworkingManager) computePermissionsForPeerPort(ctx context.Con
 		})
 	}
 
-	permissionLabels := map[string]string{tgbNetworkingIPPermissionLabelKey: tgbNetworkingIPPermissionLabelValue}
+	permissionLabels := map[string]string{tgbNetworkingIPPermissionLabelKey: m.clusterName}
 	if peer.SecurityGroup != nil {
 		groupID := peer.SecurityGroup.GroupID
 		permissions := make([]networking.IPPermissionInfo, 0, len(sdkFromToPortPairs))
@@ -483,7 +483,7 @@ func (m *defaultNetworkingManager) gcIngressPermissionsFromUnusedEndpointSGs(ctx
 	usedEndpointSGs := sets.StringKeySet(ingressPermissionsPerSG)
 	unusedEndpointSGs := endpointSGs.Difference(usedEndpointSGs)
 
-	permissionSelector := labels.SelectorFromSet(labels.Set{tgbNetworkingIPPermissionLabelKey: tgbNetworkingIPPermissionLabelValue})
+	permissionSelector := labels.SelectorFromSet(labels.Set{tgbNetworkingIPPermissionLabelKey: m.clusterName})
 	for sgID := range unusedEndpointSGs {
 		err := m.sgReconciler.ReconcileIngress(ctx, sgID, nil,
 			networking.WithPermissionSelector(permissionSelector))

--- a/pkg/targetgroupbinding/networking_manager_test.go
+++ b/pkg/targetgroupbinding/networking_manager_test.go
@@ -17,6 +17,8 @@ import (
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/networking"
 )
 
+const testClusterName = "test-123"
+
 func Test_defaultNetworkingManager_computeIngressPermissionsForTGBNetworking(t *testing.T) {
 	port8080 := intstr.FromInt(8080)
 	port8443 := intstr.FromInt(8443)
@@ -60,12 +62,12 @@ func Test_defaultNetworkingManager_computeIngressPermissionsForTGBNetworking(t *
 						ToPort:     awssdk.Int64(8080),
 						UserIdGroupPairs: []*ec2sdk.UserIdGroupPair{
 							{
-								Description: awssdk.String("elbv2.k8s.aws/targetGroupBinding=shared"),
+								Description: awssdk.String("elbv2.k8s.aws/targetGroupBinding=test-123"),
 								GroupId:     awssdk.String("sg-abcdefg"),
 							},
 						},
 					},
-					Labels: map[string]string{tgbNetworkingIPPermissionLabelKey: tgbNetworkingIPPermissionLabelValue},
+					Labels: map[string]string{tgbNetworkingIPPermissionLabelKey: testClusterName},
 				},
 			},
 		},
@@ -107,12 +109,12 @@ func Test_defaultNetworkingManager_computeIngressPermissionsForTGBNetworking(t *
 						ToPort:     awssdk.Int64(8080),
 						UserIdGroupPairs: []*ec2sdk.UserIdGroupPair{
 							{
-								Description: awssdk.String("elbv2.k8s.aws/targetGroupBinding=shared"),
+								Description: awssdk.String("elbv2.k8s.aws/targetGroupBinding=test-123"),
 								GroupId:     awssdk.String("sg-abcdefg"),
 							},
 						},
 					},
-					Labels: map[string]string{tgbNetworkingIPPermissionLabelKey: tgbNetworkingIPPermissionLabelValue},
+					Labels: map[string]string{tgbNetworkingIPPermissionLabelKey: testClusterName},
 				},
 				{
 					Permission: ec2sdk.IpPermission{
@@ -121,12 +123,12 @@ func Test_defaultNetworkingManager_computeIngressPermissionsForTGBNetworking(t *
 						ToPort:     awssdk.Int64(8443),
 						UserIdGroupPairs: []*ec2sdk.UserIdGroupPair{
 							{
-								Description: awssdk.String("elbv2.k8s.aws/targetGroupBinding=shared"),
+								Description: awssdk.String("elbv2.k8s.aws/targetGroupBinding=test-123"),
 								GroupId:     awssdk.String("sg-abcdefg"),
 							},
 						},
 					},
-					Labels: map[string]string{tgbNetworkingIPPermissionLabelKey: tgbNetworkingIPPermissionLabelValue},
+					Labels: map[string]string{tgbNetworkingIPPermissionLabelKey: testClusterName},
 				},
 				{
 					Permission: ec2sdk.IpPermission{
@@ -135,12 +137,12 @@ func Test_defaultNetworkingManager_computeIngressPermissionsForTGBNetworking(t *
 						ToPort:     awssdk.Int64(8080),
 						IpRanges: []*ec2sdk.IpRange{
 							{
-								Description: awssdk.String("elbv2.k8s.aws/targetGroupBinding=shared"),
+								Description: awssdk.String("elbv2.k8s.aws/targetGroupBinding=test-123"),
 								CidrIp:      awssdk.String("192.168.1.1/16"),
 							},
 						},
 					},
-					Labels: map[string]string{tgbNetworkingIPPermissionLabelKey: tgbNetworkingIPPermissionLabelValue},
+					Labels: map[string]string{tgbNetworkingIPPermissionLabelKey: testClusterName},
 				},
 				{
 					Permission: ec2sdk.IpPermission{
@@ -149,12 +151,12 @@ func Test_defaultNetworkingManager_computeIngressPermissionsForTGBNetworking(t *
 						ToPort:     awssdk.Int64(8443),
 						IpRanges: []*ec2sdk.IpRange{
 							{
-								Description: awssdk.String("elbv2.k8s.aws/targetGroupBinding=shared"),
+								Description: awssdk.String("elbv2.k8s.aws/targetGroupBinding=test-123"),
 								CidrIp:      awssdk.String("192.168.1.1/16"),
 							},
 						},
 					},
-					Labels: map[string]string{tgbNetworkingIPPermissionLabelKey: tgbNetworkingIPPermissionLabelValue},
+					Labels: map[string]string{tgbNetworkingIPPermissionLabelKey: testClusterName},
 				},
 			},
 		},
@@ -202,12 +204,12 @@ func Test_defaultNetworkingManager_computeIngressPermissionsForTGBNetworking(t *
 						ToPort:     awssdk.Int64(8080),
 						UserIdGroupPairs: []*ec2sdk.UserIdGroupPair{
 							{
-								Description: awssdk.String("elbv2.k8s.aws/targetGroupBinding=shared"),
+								Description: awssdk.String("elbv2.k8s.aws/targetGroupBinding=test-123"),
 								GroupId:     awssdk.String("sg-abcdefg"),
 							},
 						},
 					},
-					Labels: map[string]string{tgbNetworkingIPPermissionLabelKey: tgbNetworkingIPPermissionLabelValue},
+					Labels: map[string]string{tgbNetworkingIPPermissionLabelKey: testClusterName},
 				},
 				{
 					Permission: ec2sdk.IpPermission{
@@ -216,19 +218,21 @@ func Test_defaultNetworkingManager_computeIngressPermissionsForTGBNetworking(t *
 						ToPort:     awssdk.Int64(8443),
 						IpRanges: []*ec2sdk.IpRange{
 							{
-								Description: awssdk.String("elbv2.k8s.aws/targetGroupBinding=shared"),
+								Description: awssdk.String("elbv2.k8s.aws/targetGroupBinding=test-123"),
 								CidrIp:      awssdk.String("192.168.1.1/16"),
 							},
 						},
 					},
-					Labels: map[string]string{tgbNetworkingIPPermissionLabelKey: tgbNetworkingIPPermissionLabelValue},
+					Labels: map[string]string{tgbNetworkingIPPermissionLabelKey: testClusterName},
 				},
 			},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			m := &defaultNetworkingManager{}
+			m := &defaultNetworkingManager{
+                clusterName: testClusterName,
+            }
 			got, err := m.computeIngressPermissionsForTGBNetworking(context.Background(), tt.args.tgbNetworking, tt.args.pods)
 			if tt.wantErr != nil {
 				assert.EqualError(t, err, tt.wantErr.Error())
@@ -277,12 +281,12 @@ func Test_defaultNetworkingManager_computePermissionsForPeerPort(t *testing.T) {
 						ToPort:     awssdk.Int64(8080),
 						UserIdGroupPairs: []*ec2sdk.UserIdGroupPair{
 							{
-								Description: awssdk.String("elbv2.k8s.aws/targetGroupBinding=shared"),
+								Description: awssdk.String("elbv2.k8s.aws/targetGroupBinding=test-123"),
 								GroupId:     awssdk.String("sg-abcdefg"),
 							},
 						},
 					},
-					Labels: map[string]string{tgbNetworkingIPPermissionLabelKey: tgbNetworkingIPPermissionLabelValue},
+					Labels: map[string]string{tgbNetworkingIPPermissionLabelKey: testClusterName},
 				},
 			},
 		},
@@ -309,11 +313,11 @@ func Test_defaultNetworkingManager_computePermissionsForPeerPort(t *testing.T) {
 						IpRanges: []*ec2sdk.IpRange{
 							{
 								CidrIp:      awssdk.String("192.168.1.1/16"),
-								Description: awssdk.String("elbv2.k8s.aws/targetGroupBinding=shared"),
+								Description: awssdk.String("elbv2.k8s.aws/targetGroupBinding=test-123"),
 							},
 						},
 					},
-					Labels: map[string]string{tgbNetworkingIPPermissionLabelKey: tgbNetworkingIPPermissionLabelValue},
+					Labels: map[string]string{tgbNetworkingIPPermissionLabelKey: testClusterName},
 				},
 			},
 		},
@@ -340,11 +344,11 @@ func Test_defaultNetworkingManager_computePermissionsForPeerPort(t *testing.T) {
 						Ipv6Ranges: []*ec2sdk.Ipv6Range{
 							{
 								CidrIpv6:    awssdk.String("2002::1234:abcd:ffff:c0a8:101/64"),
-								Description: awssdk.String("elbv2.k8s.aws/targetGroupBinding=shared"),
+								Description: awssdk.String("elbv2.k8s.aws/targetGroupBinding=test-123"),
 							},
 						},
 					},
-					Labels: map[string]string{tgbNetworkingIPPermissionLabelKey: tgbNetworkingIPPermissionLabelValue},
+					Labels: map[string]string{tgbNetworkingIPPermissionLabelKey: testClusterName},
 				},
 			},
 		},
@@ -389,12 +393,12 @@ func Test_defaultNetworkingManager_computePermissionsForPeerPort(t *testing.T) {
 						ToPort:     awssdk.Int64(80),
 						UserIdGroupPairs: []*ec2sdk.UserIdGroupPair{
 							{
-								Description: awssdk.String("elbv2.k8s.aws/targetGroupBinding=shared"),
+								Description: awssdk.String("elbv2.k8s.aws/targetGroupBinding=test-123"),
 								GroupId:     awssdk.String("sg-abcdefg"),
 							},
 						},
 					},
-					Labels: map[string]string{tgbNetworkingIPPermissionLabelKey: tgbNetworkingIPPermissionLabelValue},
+					Labels: map[string]string{tgbNetworkingIPPermissionLabelKey: testClusterName},
 				},
 				{
 					Permission: ec2sdk.IpPermission{
@@ -403,12 +407,12 @@ func Test_defaultNetworkingManager_computePermissionsForPeerPort(t *testing.T) {
 						ToPort:     awssdk.Int64(8080),
 						UserIdGroupPairs: []*ec2sdk.UserIdGroupPair{
 							{
-								Description: awssdk.String("elbv2.k8s.aws/targetGroupBinding=shared"),
+								Description: awssdk.String("elbv2.k8s.aws/targetGroupBinding=test-123"),
 								GroupId:     awssdk.String("sg-abcdefg"),
 							},
 						},
 					},
-					Labels: map[string]string{tgbNetworkingIPPermissionLabelKey: tgbNetworkingIPPermissionLabelValue},
+					Labels: map[string]string{tgbNetworkingIPPermissionLabelKey: testClusterName},
 				},
 			},
 		},
@@ -434,12 +438,12 @@ func Test_defaultNetworkingManager_computePermissionsForPeerPort(t *testing.T) {
 						ToPort:     awssdk.Int64(8080),
 						UserIdGroupPairs: []*ec2sdk.UserIdGroupPair{
 							{
-								Description: awssdk.String("elbv2.k8s.aws/targetGroupBinding=shared"),
+								Description: awssdk.String("elbv2.k8s.aws/targetGroupBinding=test-123"),
 								GroupId:     awssdk.String("sg-abcdefg"),
 							},
 						},
 					},
-					Labels: map[string]string{tgbNetworkingIPPermissionLabelKey: tgbNetworkingIPPermissionLabelValue},
+					Labels: map[string]string{tgbNetworkingIPPermissionLabelKey: testClusterName},
 				},
 			},
 		},
@@ -464,19 +468,21 @@ func Test_defaultNetworkingManager_computePermissionsForPeerPort(t *testing.T) {
 						ToPort:     awssdk.Int64(65535),
 						UserIdGroupPairs: []*ec2sdk.UserIdGroupPair{
 							{
-								Description: awssdk.String("elbv2.k8s.aws/targetGroupBinding=shared"),
+								Description: awssdk.String("elbv2.k8s.aws/targetGroupBinding=test-123"),
 								GroupId:     awssdk.String("sg-abcdefg"),
 							},
 						},
 					},
-					Labels: map[string]string{tgbNetworkingIPPermissionLabelKey: tgbNetworkingIPPermissionLabelValue},
+					Labels: map[string]string{tgbNetworkingIPPermissionLabelKey: testClusterName},
 				},
 			},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			m := &defaultNetworkingManager{}
+			m := &defaultNetworkingManager{
+                clusterName: testClusterName,
+            }
 			got, err := m.computePermissionsForPeerPort(context.Background(), tt.args.peer, tt.args.port, tt.args.pods)
 			if tt.wantErr != nil {
 				assert.EqualError(t, err, tt.wantErr.Error())

--- a/pkg/targetgroupbinding/resource_manager.go
+++ b/pkg/targetgroupbinding/resource_manager.go
@@ -38,10 +38,10 @@ type ResourceManager interface {
 func NewDefaultResourceManager(k8sClient client.Client, elbv2Client services.ELBV2, ec2Client services.EC2,
 	podInfoRepo k8s.PodInfoRepo, sgManager networking.SecurityGroupManager, sgReconciler networking.SecurityGroupReconciler,
 	vpcInfoProvider networking.VPCInfoProvider,
-	vpcID string, clusterName string, failOpenEnabled bool, endpointSliceEnabled bool, disabledRestrictedSGRulesFlag bool,
+	vpcID string, clusterName string, cidrBlocks []string, failOpenEnabled bool, endpointSliceEnabled bool, disabledRestrictedSGRulesFlag bool,
 	endpointSGTags map[string]string,
 	eventRecorder record.EventRecorder, logger logr.Logger) *defaultResourceManager {
-	targetsManager := NewCachedTargetsManager(elbv2Client, logger)
+	targetsManager := NewCachedTargetsManager(elbv2Client, cidrBlocks, logger)
 	endpointResolver := backend.NewDefaultEndpointResolver(k8sClient, podInfoRepo, failOpenEnabled, endpointSliceEnabled, logger)
 
 	nodeInfoProvider := networking.NewDefaultNodeInfoProvider(ec2Client, logger)


### PR DESCRIPTION
https://github.com/dlmather/aws-load-balancer-controller/pull/1 but rebased to 2.8.1

There's a commit I cherry-picked from https://github.com/dlmather/aws-load-balancer-controller/commit/58b5ff356086b4920d6e3e2f5d705bf29cb3c27f which we still need to support.