### PR TITLE
mega target group v2.7.2

### DIFF
--- a/pkg/backend/endpoint_types.go
+++ b/pkg/backend/endpoint_types.go
@@ -1,6 +1,8 @@
 package backend
 
 import (
+	"net/netip"
+
 	corev1 "k8s.io/api/core/v1"
 	discv1 "k8s.io/api/discovery/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -41,6 +43,9 @@ type EndpointResolveOptions struct {
 	// [Pod Endpoint] if pod readinessGates is defined, then pods from unready addresses with any of these readinessGates and containersReady condition will be included as well.
 	// By default, no readinessGate is specified.
 	PodReadinessGates []corev1.PodConditionType
+
+	// cidrs will be used to filter out the list of IPs returned by the resolver
+	cidrs []netip.Prefix
 }
 
 func (opts *EndpointResolveOptions) ApplyOptions(options []EndpointResolveOption) {
@@ -62,6 +67,14 @@ func WithNodeSelector(nodeSelector labels.Selector) EndpointResolveOption {
 func WithPodReadinessGate(cond corev1.PodConditionType) EndpointResolveOption {
 	return func(opts *EndpointResolveOptions) {
 		opts.PodReadinessGates = append(opts.PodReadinessGates, cond)
+	}
+}
+
+// WithCIDRRanges is an option that appends cidrs into EndpointResolveOptions to filter
+// out the set of IPs to register
+func WithCIDRRanges(cidrs []netip.Prefix) EndpointResolveOption {
+	return func(opts *EndpointResolveOptions) {
+		opts.cidrs = cidrs
 	}
 }
 

--- a/pkg/targetgroupbinding/networking_manager.go
+++ b/pkg/targetgroupbinding/networking_manager.go
@@ -201,7 +201,7 @@ func (m *defaultNetworkingManager) reconcileWithIngressPermissionsPerSG(ctx cont
 	computedForAllTGBs := m.consolidateIngressPermissionsPerSGByTGB(ctx, tgbsWithNetworking)
 	aggregatedIngressPermissionsPerSG := m.computeAggregatedIngressPermissionsPerSG(ctx)
 
-	permissionSelector := labels.SelectorFromSet(labels.Set{tgbNetworkingIPPermissionLabelKey: tgbNetworkingIPPermissionLabelValue})
+	permissionSelector := labels.SelectorFromSet(labels.Set{tgbNetworkingIPPermissionLabelKey: m.clusterName})
 	var sgReconciliationErrors []error
 	for sgID, permissions := range aggregatedIngressPermissionsPerSG {
 		if err := m.sgReconciler.ReconcileIngress(ctx, sgID, permissions,
@@ -420,7 +420,7 @@ func (m *defaultNetworkingManager) computePermissionsForPeerPort(ctx context.Con
 		})
 	}
 
-	permissionLabels := map[string]string{tgbNetworkingIPPermissionLabelKey: tgbNetworkingIPPermissionLabelValue}
+	permissionLabels := map[string]string{tgbNetworkingIPPermissionLabelKey: m.clusterName}
 	if peer.SecurityGroup != nil {
 		groupID := peer.SecurityGroup.GroupID
 		permissions := make([]networking.IPPermissionInfo, 0, len(sdkFromToPortPairs))
@@ -483,7 +483,7 @@ func (m *defaultNetworkingManager) gcIngressPermissionsFromUnusedEndpointSGs(ctx
 	usedEndpointSGs := sets.StringKeySet(ingressPermissionsPerSG)
 	unusedEndpointSGs := endpointSGs.Difference(usedEndpointSGs)
 
-	permissionSelector := labels.SelectorFromSet(labels.Set{tgbNetworkingIPPermissionLabelKey: tgbNetworkingIPPermissionLabelValue})
+	permissionSelector := labels.SelectorFromSet(labels.Set{tgbNetworkingIPPermissionLabelKey: m.clusterName})
 	for sgID := range unusedEndpointSGs {
 		err := m.sgReconciler.ReconcileIngress(ctx, sgID, nil,
 			networking.WithPermissionSelector(permissionSelector))

--- a/pkg/targetgroupbinding/networking_manager_test.go
+++ b/pkg/targetgroupbinding/networking_manager_test.go
@@ -17,6 +17,8 @@ import (
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/networking"
 )
 
+const testClusterName = "test-123"
+
 func Test_defaultNetworkingManager_computeIngressPermissionsForTGBNetworking(t *testing.T) {
 	port8080 := intstr.FromInt(8080)
 	port8443 := intstr.FromInt(8443)
@@ -60,12 +62,12 @@ func Test_defaultNetworkingManager_computeIngressPermissionsForTGBNetworking(t *
 						ToPort:     awssdk.Int64(8080),
 						UserIdGroupPairs: []*ec2sdk.UserIdGroupPair{
 							{
-								Description: awssdk.String("elbv2.k8s.aws/targetGroupBinding=shared"),
+								Description: awssdk.String("elbv2.k8s.aws/targetGroupBinding=test-123"),
 								GroupId:     awssdk.String("sg-abcdefg"),
 							},
 						},
 					},
-					Labels: map[string]string{tgbNetworkingIPPermissionLabelKey: tgbNetworkingIPPermissionLabelValue},
+					Labels: map[string]string{tgbNetworkingIPPermissionLabelKey: testClusterName},
 				},
 			},
 		},
@@ -107,12 +109,12 @@ func Test_defaultNetworkingManager_computeIngressPermissionsForTGBNetworking(t *
 						ToPort:     awssdk.Int64(8080),
 						UserIdGroupPairs: []*ec2sdk.UserIdGroupPair{
 							{
-								Description: awssdk.String("elbv2.k8s.aws/targetGroupBinding=shared"),
+								Description: awssdk.String("elbv2.k8s.aws/targetGroupBinding=test-123"),
 								GroupId:     awssdk.String("sg-abcdefg"),
 							},
 						},
 					},
-					Labels: map[string]string{tgbNetworkingIPPermissionLabelKey: tgbNetworkingIPPermissionLabelValue},
+					Labels: map[string]string{tgbNetworkingIPPermissionLabelKey: testClusterName},
 				},
 				{
 					Permission: ec2sdk.IpPermission{
@@ -121,12 +123,12 @@ func Test_defaultNetworkingManager_computeIngressPermissionsForTGBNetworking(t *
 						ToPort:     awssdk.Int64(8443),
 						UserIdGroupPairs: []*ec2sdk.UserIdGroupPair{
 							{
-								Description: awssdk.String("elbv2.k8s.aws/targetGroupBinding=shared"),
+								Description: awssdk.String("elbv2.k8s.aws/targetGroupBinding=test-123"),
 								GroupId:     awssdk.String("sg-abcdefg"),
 							},
 						},
 					},
-					Labels: map[string]string{tgbNetworkingIPPermissionLabelKey: tgbNetworkingIPPermissionLabelValue},
+					Labels: map[string]string{tgbNetworkingIPPermissionLabelKey: testClusterName},
 				},
 				{
 					Permission: ec2sdk.IpPermission{
@@ -135,12 +137,12 @@ func Test_defaultNetworkingManager_computeIngressPermissionsForTGBNetworking(t *
 						ToPort:     awssdk.Int64(8080),
 						IpRanges: []*ec2sdk.IpRange{
 							{
-								Description: awssdk.String("elbv2.k8s.aws/targetGroupBinding=shared"),
+								Description: awssdk.String("elbv2.k8s.aws/targetGroupBinding=test-123"),
 								CidrIp:      awssdk.String("192.168.1.1/16"),
 							},
 						},
 					},
-					Labels: map[string]string{tgbNetworkingIPPermissionLabelKey: tgbNetworkingIPPermissionLabelValue},
+					Labels: map[string]string{tgbNetworkingIPPermissionLabelKey: testClusterName},
 				},
 				{
 					Permission: ec2sdk.IpPermission{
@@ -149,12 +151,12 @@ func Test_defaultNetworkingManager_computeIngressPermissionsForTGBNetworking(t *
 						ToPort:     awssdk.Int64(8443),
 						IpRanges: []*ec2sdk.IpRange{
 							{
-								Description: awssdk.String("elbv2.k8s.aws/targetGroupBinding=shared"),
+								Description: awssdk.String("elbv2.k8s.aws/targetGroupBinding=test-123"),
 								CidrIp:      awssdk.String("192.168.1.1/16"),
 							},
 						},
 					},
-					Labels: map[string]string{tgbNetworkingIPPermissionLabelKey: tgbNetworkingIPPermissionLabelValue},
+					Labels: map[string]string{tgbNetworkingIPPermissionLabelKey: testClusterName},
 				},
 			},
 		},
@@ -202,12 +204,12 @@ func Test_defaultNetworkingManager_computeIngressPermissionsForTGBNetworking(t *
 						ToPort:     awssdk.Int64(8080),
 						UserIdGroupPairs: []*ec2sdk.UserIdGroupPair{
 							{
-								Description: awssdk.String("elbv2.k8s.aws/targetGroupBinding=shared"),
+								Description: awssdk.String("elbv2.k8s.aws/targetGroupBinding=test-123"),
 								GroupId:     awssdk.String("sg-abcdefg"),
 							},
 						},
 					},
-					Labels: map[string]string{tgbNetworkingIPPermissionLabelKey: tgbNetworkingIPPermissionLabelValue},
+					Labels: map[string]string{tgbNetworkingIPPermissionLabelKey: testClusterName},
 				},
 				{
 					Permission: ec2sdk.IpPermission{
@@ -216,19 +218,21 @@ func Test_defaultNetworkingManager_computeIngressPermissionsForTGBNetworking(t *
 						ToPort:     awssdk.Int64(8443),
 						IpRanges: []*ec2sdk.IpRange{
 							{
-								Description: awssdk.String("elbv2.k8s.aws/targetGroupBinding=shared"),
+								Description: awssdk.String("elbv2.k8s.aws/targetGroupBinding=test-123"),
 								CidrIp:      awssdk.String("192.168.1.1/16"),
 							},
 						},
 					},
-					Labels: map[string]string{tgbNetworkingIPPermissionLabelKey: tgbNetworkingIPPermissionLabelValue},
+					Labels: map[string]string{tgbNetworkingIPPermissionLabelKey: testClusterName},
 				},
 			},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			m := &defaultNetworkingManager{}
+			m := &defaultNetworkingManager{
+                clusterName: testClusterName,
+            }
 			got, err := m.computeIngressPermissionsForTGBNetworking(context.Background(), tt.args.tgbNetworking, tt.args.pods)
 			if tt.wantErr != nil {
 				assert.EqualError(t, err, tt.wantErr.Error())
@@ -277,12 +281,12 @@ func Test_defaultNetworkingManager_computePermissionsForPeerPort(t *testing.T) {
 						ToPort:     awssdk.Int64(8080),
 						UserIdGroupPairs: []*ec2sdk.UserIdGroupPair{
 							{
-								Description: awssdk.String("elbv2.k8s.aws/targetGroupBinding=shared"),
+								Description: awssdk.String("elbv2.k8s.aws/targetGroupBinding=test-123"),
 								GroupId:     awssdk.String("sg-abcdefg"),
 							},
 						},
 					},
-					Labels: map[string]string{tgbNetworkingIPPermissionLabelKey: tgbNetworkingIPPermissionLabelValue},
+					Labels: map[string]string{tgbNetworkingIPPermissionLabelKey: testClusterName},
 				},
 			},
 		},
@@ -309,11 +313,11 @@ func Test_defaultNetworkingManager_computePermissionsForPeerPort(t *testing.T) {
 						IpRanges: []*ec2sdk.IpRange{
 							{
 								CidrIp:      awssdk.String("192.168.1.1/16"),
-								Description: awssdk.String("elbv2.k8s.aws/targetGroupBinding=shared"),
+								Description: awssdk.String("elbv2.k8s.aws/targetGroupBinding=test-123"),
 							},
 						},
 					},
-					Labels: map[string]string{tgbNetworkingIPPermissionLabelKey: tgbNetworkingIPPermissionLabelValue},
+					Labels: map[string]string{tgbNetworkingIPPermissionLabelKey: testClusterName},
 				},
 			},
 		},
@@ -340,11 +344,11 @@ func Test_defaultNetworkingManager_computePermissionsForPeerPort(t *testing.T) {
 						Ipv6Ranges: []*ec2sdk.Ipv6Range{
 							{
 								CidrIpv6:    awssdk.String("2002::1234:abcd:ffff:c0a8:101/64"),
-								Description: awssdk.String("elbv2.k8s.aws/targetGroupBinding=shared"),
+								Description: awssdk.String("elbv2.k8s.aws/targetGroupBinding=test-123"),
 							},
 						},
 					},
-					Labels: map[string]string{tgbNetworkingIPPermissionLabelKey: tgbNetworkingIPPermissionLabelValue},
+					Labels: map[string]string{tgbNetworkingIPPermissionLabelKey: testClusterName},
 				},
 			},
 		},
@@ -389,12 +393,12 @@ func Test_defaultNetworkingManager_computePermissionsForPeerPort(t *testing.T) {
 						ToPort:     awssdk.Int64(80),
 						UserIdGroupPairs: []*ec2sdk.UserIdGroupPair{
 							{
-								Description: awssdk.String("elbv2.k8s.aws/targetGroupBinding=shared"),
+								Description: awssdk.String("elbv2.k8s.aws/targetGroupBinding=test-123"),
 								GroupId:     awssdk.String("sg-abcdefg"),
 							},
 						},
 					},
-					Labels: map[string]string{tgbNetworkingIPPermissionLabelKey: tgbNetworkingIPPermissionLabelValue},
+					Labels: map[string]string{tgbNetworkingIPPermissionLabelKey: testClusterName},
 				},
 				{
 					Permission: ec2sdk.IpPermission{
@@ -403,12 +407,12 @@ func Test_defaultNetworkingManager_computePermissionsForPeerPort(t *testing.T) {
 						ToPort:     awssdk.Int64(8080),
 						UserIdGroupPairs: []*ec2sdk.UserIdGroupPair{
 							{
-								Description: awssdk.String("elbv2.k8s.aws/targetGroupBinding=shared"),
+								Description: awssdk.String("elbv2.k8s.aws/targetGroupBinding=test-123"),
 								GroupId:     awssdk.String("sg-abcdefg"),
 							},
 						},
 					},
-					Labels: map[string]string{tgbNetworkingIPPermissionLabelKey: tgbNetworkingIPPermissionLabelValue},
+					Labels: map[string]string{tgbNetworkingIPPermissionLabelKey: testClusterName},
 				},
 			},
 		},
@@ -434,12 +438,12 @@ func Test_defaultNetworkingManager_computePermissionsForPeerPort(t *testing.T) {
 						ToPort:     awssdk.Int64(8080),
 						UserIdGroupPairs: []*ec2sdk.UserIdGroupPair{
 							{
-								Description: awssdk.String("elbv2.k8s.aws/targetGroupBinding=shared"),
+								Description: awssdk.String("elbv2.k8s.aws/targetGroupBinding=test-123"),
 								GroupId:     awssdk.String("sg-abcdefg"),
 							},
 						},
 					},
-					Labels: map[string]string{tgbNetworkingIPPermissionLabelKey: tgbNetworkingIPPermissionLabelValue},
+					Labels: map[string]string{tgbNetworkingIPPermissionLabelKey: testClusterName},
 				},
 			},
 		},
@@ -464,19 +468,21 @@ func Test_defaultNetworkingManager_computePermissionsForPeerPort(t *testing.T) {
 						ToPort:     awssdk.Int64(65535),
 						UserIdGroupPairs: []*ec2sdk.UserIdGroupPair{
 							{
-								Description: awssdk.String("elbv2.k8s.aws/targetGroupBinding=shared"),
+								Description: awssdk.String("elbv2.k8s.aws/targetGroupBinding=test-123"),
 								GroupId:     awssdk.String("sg-abcdefg"),
 							},
 						},
 					},
-					Labels: map[string]string{tgbNetworkingIPPermissionLabelKey: tgbNetworkingIPPermissionLabelValue},
+					Labels: map[string]string{tgbNetworkingIPPermissionLabelKey: testClusterName},
 				},
 			},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			m := &defaultNetworkingManager{}
+			m := &defaultNetworkingManager{
+                clusterName: testClusterName,
+            }
 			got, err := m.computePermissionsForPeerPort(context.Background(), tt.args.peer, tt.args.port, tt.args.pods)
 			if tt.wantErr != nil {
 				assert.EqualError(t, err, tt.wantErr.Error())


### PR DESCRIPTION
- This effectively passes down the CIDR blocks as a flag and filters the list of targets that are returned from aws.
- parse cidrs at main func
- filter out epAddr in endpoint resolver
- instead of reading cidrs from the flag, we can incrementally onboard new services